### PR TITLE
Fixed base_url for .csl and .css so jupyterhub users can utilize the extension.

### DIFF
--- a/cite2c/nbext/main.js
+++ b/cite2c/nbext/main.js
@@ -309,7 +309,13 @@ function($, dialog, utils, configmod, rendering) {
     function load_ipython_extension() {
         toolbar_buttons();
         rendering.init_rendering();
-        $('head').append('<link rel="stylesheet" href="/nbextensions/cite2c/styles.css" type="text/css" />');
+	var base_url = utils.get_body_data("baseUrl");
+	$('head').append(
+	    $('<link>')
+		.attr('rel','stylesheet')
+		.attr('type','text/css')
+		.attr('href', base_url + 'nbextensions/cite2c/styles.css')
+	);
     }
 
     return {load_ipython_extension: load_ipython_extension};

--- a/cite2c/nbext/main.js
+++ b/cite2c/nbext/main.js
@@ -309,12 +309,12 @@ function($, dialog, utils, configmod, rendering) {
     function load_ipython_extension() {
         toolbar_buttons();
         rendering.init_rendering();
-	var base_url = utils.get_body_data("baseUrl");
 	$('head').append(
 	    $('<link>')
 		.attr('rel','stylesheet')
 		.attr('type','text/css')
-		.attr('href', base_url + 'nbextensions/cite2c/styles.css')
+		.attr('href', utils.url_path_join(utils.get_body_data("baseUrl"),
+						  'nbextensions/cite2c/styles.css'))
 	);
     }
 

--- a/cite2c/nbext/rendering.js
+++ b/cite2c/nbext/rendering.js
@@ -121,8 +121,8 @@ function($, utils, CSL) {
     function init_rendering() {
         // Create a CSL engine, hook it up to the MarkdownCell rendered event,
         // and process all citations already in the document.
-	var base_url = utils.get_body_data("baseUrl");
-        $.ajax(base_url + "nbextensions/cite2c/chicago-author-date.csl", {
+        $.ajax(utils.url_path_join(utils.get_body_data("baseUrl"),
+				   'nbextensions/cite2c/chicago-author-date.csl'), {
             dataType: "text",
             success: function(styleAsText, textStatus, jqXHR) {
                 citeproc = new CSL.Engine(cpSys, styleAsText);

--- a/cite2c/nbext/rendering.js
+++ b/cite2c/nbext/rendering.js
@@ -121,7 +121,8 @@ function($, utils, CSL) {
     function init_rendering() {
         // Create a CSL engine, hook it up to the MarkdownCell rendered event,
         // and process all citations already in the document.
-        $.ajax("/nbextensions/cite2c/chicago-author-date.csl", {
+	var base_url = utils.get_body_data("baseUrl");
+        $.ajax(base_url + "nbextensions/cite2c/chicago-author-date.csl", {
             dataType: "text",
             success: function(styleAsText, textStatus, jqXHR) {
                 citeproc = new CSL.Engine(cpSys, styleAsText);


### PR DESCRIPTION
When wanting to use the extension under JupyterHub, there were a couple of files that could not be found at the urls currently defined in the code. Mainly, the urls for some necessary files (chicago-author-date.csl and styles.css) were assuming the base url for the notebook server (/) was where the nbextensions folder would be, but jupyterhub adds /user/{username} onto this and additional jupyterhub settings which can prefix an even longer path on this.

I've updated main.js and rendering.js to find the base url using utils.get_body_data("baseUrl") and add this as a prefix to the locations of these files, which seems to fix the issue and allows the extension to work with JupyterHub.

Even after this change, each individual user needs to run 'python -m cite2c.install' in order to set up extension. However, the extension didn't work at all with JupyterHub before this change, and the new code looks to remain compatible with standard notebook server installations.